### PR TITLE
Added new download url for iso currencies list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import warnings
 from setuptools import setup
 
 
-table_url = 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml'
+table_url = 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml'  # noqa: E501
 
 
 # Override if ISO4217_DOWNLOAD_URL is set

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import warnings
 from setuptools import setup
 
 
-table_url = 'http://www.currency-iso.org/dam/downloads/lists/list_one.xml'
+table_url = 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml'
 
 
 # Override if ISO4217_DOWNLOAD_URL is set


### PR DESCRIPTION
Added new URL for `list1.xml` which is used to get the currencies list. `currency-iso` is moved to `six-group`.

New URL: https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml

ref: https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=isin