### PR TITLE
Change license from Public Domain to The Unlicense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,13 +6,12 @@ long_description_content_type = text/x-rst; charset=UTF-8
 url = https://github.com/dahlia/iso4217
 author = Hong Minhee
 author_email = hong.minhee@gmail.com
-license = Public Domain
+license = The Unlicense
 keywords = internationalization i18n currency iso4217
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: Public Domain
     Operating System :: OS Independent
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6


### PR DESCRIPTION
Some countries don't recognize `Public Domain` as valid license. It's often suggested to use `The Unlicense` in these cases.

https://choosealicense.com/licenses/unlicense/